### PR TITLE
fix: pass src for script type element

### DIFF
--- a/src/core/alpine-lazy-load-assets.js
+++ b/src/core/alpine-lazy-load-assets.js
@@ -47,7 +47,8 @@ export default function (Alpine) {
             return Promise.resolve()
         }
 
-        const element = createDomElement(elementType, { ...attributes, href: path }, targetElement, insertBeforeElement);
+        const elementAttributes = elementType === "link" ? { ...attributes, href: path } : { ...attributes, src: path }
+        const element = createDomElement(elementType, elementAttributes, targetElement, insertBeforeElement);
 
         return new Promise((resolve, reject) => {
             element.onload = () => {


### PR DESCRIPTION
Hi!
Looks like last refactoring breaks JS loading. I think it's because of passing `href` for both link and script.
Please take a look.

P.S. Would be cool to add tests for a project. They could help to catch such bugs.